### PR TITLE
Merge Obj_Item_speed to Main

### DIFF
--- a/An Untitled Mining Game/An Untitled Mining Game/objects/obj_item/Create_0.gml
+++ b/An Untitled Mining Game/An Untitled Mining Game/objects/obj_item/Create_0.gml
@@ -9,7 +9,8 @@ spr_width = sprite_get_width(item_spr);
 //----------
 // Info for subsprite
 //----------
-//item_nun = 1;
+item_num = 0;
+item_amount = 1;
 x_frame = 0;
 y_frame = 0;
 
@@ -27,3 +28,7 @@ var itemdir = irandom_range(0, 359);
 var len =  irandom_range(cell_size * .9, cell_size * 1.5);
 x_goal = x + lengthdir_x(len, itemdir);
 y_goal = y + lengthdir_y(len, itemdir);;
+
+lerp_speed = .15;
+dectition_radius = 32;
+pickup_radius = 4;

--- a/An Untitled Mining Game/An Untitled Mining Game/objects/obj_item/Step_0.gml
+++ b/An Untitled Mining Game/An Untitled Mining Game/objects/obj_item/Step_0.gml
@@ -3,35 +3,52 @@ clamp(x, 0, global.ScreenWidth);
 clamp(y, 0, global.ScreenHeight);
 
 
-if (drop_move) {
+if (drop_move) { //inital Spawn
 	x = lerp(x, x_goal, .1);	
 	y = lerp(y, y_goal, .1);
 	if ((abs(x - x_goal) < 1) and (abs(y - y_goal) < 1)) {
 		drop_move = false;
 	}
 } else {
+	// Is inventory full
+	var in = item_num;
+	with(obj_inventory) {
+			var ds_inv = ds_inventory
+			var inventory_full = true;
+			//check if item exists already
+			var ii = 0; repeat(inv_slots){
+				if ((ds_inv[# 0, ii] == 0) or (ds_inv[# 0, ii] == in)) { //if there is an empty slot or a slot of the same item
+					inventory_full = false;
+					break;
+				} else {
+					ii += 1;
+				}
+			}
+	}
+	if (inventory_full) exit;
+	
 	var px = obj_player.x;
 	var py = obj_player.y;
-	var r = 32;
+	var r = dectition_radius;
+	var ia = item_amount;
 	
 	if (point_in_rectangle(px, py, x - r, y - r, x + r, y + r)) { // if player within dection radius
 		//Am I at the player?
-		r = 2
+		r = pickup_radius;
 		if !(point_in_rectangle(px, py, x - r, y - r, x + r, y + r)) {
 			//no, move to player
-			x = lerp(x, px, .1);	
-			y = lerp(y, py, .1);
+			x = lerp(x, px, lerp_speed);	
+			y = lerp(y, py, lerp_speed);
 		} else {
-			//yes, pickup and destroy
-			var in = item_num;
 			
+			//yes, pickup and destroy
 			with(obj_inventory) {
 				var ds_inv = ds_inventory
 				var picked_up = false;
 				//check if item exists already
 				var ii = 0; repeat(inv_slots){
 					if (ds_inv[# 0, ii] == in) {
-						ds_inv[# 1, ii] += 1;
+						ds_inv[# 1, ii] += ia;
 						picked_up = true;
 						break;
 					} else {
@@ -53,7 +70,7 @@ if (drop_move) {
 					}
 				}
 				
-				//inventory full
+
 			}
 			//destroy item
 			if(picked_up) {

--- a/An Untitled Mining Game/An Untitled Mining Game/scripts/scr_load_game/scr_load_game.gml
+++ b/An Untitled Mining Game/An Untitled Mining Game/scripts/scr_load_game/scr_load_game.gml
@@ -53,6 +53,7 @@ if (file_exists("savegame.sav")) {
 					item_num = load_entity.item_num;
 					x_frame = load_entity.x_frame;
 					y_frame = load_entity.y_frame;
+					drop_move = false; // Assumed, so not needed in save file
 					break;
 			//-----Structs
 				case "obj_structure_parent":


### PR DESCRIPTION
### Description
I've updated obj_item to use instance variables to determine the lerp speed, the detection radius, and the pickup radius. I've also increased those so the items move towards the player faster. I went into the save file and added "drop_move = false" to the obj_item section so that items no longer "dance" when you load a save file. In the lerp calculation, I added an exception so that if the player's inventory is full, objects will not lerp towards them they will just sit on the ground. I did this because I'm following the player around even though they didn't have room for it felt weird.
I have also gone in and put a placeholder variable for item amounts so that if I do end up implementing the resource chunking idea I'll have the variable that I need to change ready.

### Files Changed
- obj_item
- scr_load_game